### PR TITLE
Changed previousTrack to backTrack

### DIFF
--- a/HighSierraMediaKeyEnabler/AppDelegate.m
+++ b/HighSierraMediaKeyEnabler/AppDelegate.m
@@ -55,7 +55,7 @@
                     break;
                     
                 case NX_KEYTYPE_REWIND:
-                    if ( [iTunes isRunning ] ) [iTunes previousTrack];
+                    if ( [iTunes isRunning ] ) [iTunes backTrack];
                     if ( [spotify isRunning ] ) [spotify previousTrack];
                     break;
                 default:


### PR DESCRIPTION
This restores the default behaviour of the "rewind" media key in iTunes.

I didn't change spotify the same way because I don't know (and don't know how to check) if it has the same method.